### PR TITLE
Add new option, filter and bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circleci",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Node.js client for CircleCI",
   "main": "dist/circleci.js",
   "scripts": {

--- a/src/routes.json
+++ b/src/routes.json
@@ -20,7 +20,8 @@
     "path": "\/project\/:username\/:project",
     "options": [
       "limit",
-      "offset"
+      "offset",
+      "filter"
     ]
   },
   "getBranchBuilds": {


### PR DESCRIPTION
See https://circleci.com/docs/api#recent-builds-project, which includes a new optional parameter `filter`, which `Restricts which builds are returned. Set to "completed", "successful", "failed", "running", or defaults to no filter.`