### PR TITLE
Added filter to allowed options on getBranchBuilds

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -29,7 +29,8 @@
     "path": "\/project\/:username\/:project\/tree\/:branch",
     "options": [
       "limit",
-      "offset"
+      "offset",
+      "filter"
     ]
   },
   "getBuild": {


### PR DESCRIPTION
`getBranchBuilds` was missing the `filter` option causing a provided filter to be ignored. The `filter` option was added to the options list to remedy this issue.