### PR TITLE
Added filter to allowed options on getBranchBuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ ci.getBranchBuilds({ username: "jpstevens", project: "circleci", branch: "master
 - **branch** [required] - The branch name you wish to use as filter
 - **limit** [optional] - The number of builds to return. Maximum 100, defaults to 30)
 - **offset** [optional] - The API returns builds starting from this offset, defaults to 0)
+- **filter** [optional] - Show only successful/failed/running/pending builds
 
 ### getBuild
 

--- a/src/routes.json
+++ b/src/routes.json
@@ -29,7 +29,8 @@
     "path": "\/project\/:username\/:project\/tree\/:branch",
     "options": [
       "limit",
-      "offset"
+      "offset",
+      "filter"
     ]
   },
   "getBuild": {

--- a/tests/unit/circleci-spec.coffee
+++ b/tests/unit/circleci-spec.coffee
@@ -75,7 +75,7 @@ describe "CircleCI Client", ->
     describe "getBranchBuilds", ->
 
       before ->
-        @route = { path: "/project/:username/:project/tree/:branch", method: "GET", options: ["limit", "offset"] }
+        @route = { path: "/project/:username/:project/tree/:branch", method: "GET", options: ["limit", "offset", "filter"] }
         @options = { username: "jpstevens", project: "circleci", branch: "master", limit: 10, offset: 100 }
 
       it "gets the builds for a project", ->


### PR DESCRIPTION
`getBranchBuilds` was missing the `filter` option causing a provided filter to be ignored. The `filter` option was added to the options list and included in the unit tests to remedy this issue.