### PR TITLE
Correcting the readme for references to startBuild as we can now pass…

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,6 @@ ci.getBuild({
 
 Triggers a new build, returns a summary of the build.
 
-**NOTE:** This client does not *yet* support the sending of [optional build parameters.](https://circleci.com/docs/parameterized-builds)
-
 #### Example Usage
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -161,6 +161,25 @@ ci.startBuild({
 - **username** [required] - The username for the project
 - **project** [required] - The project (repo) name
 - **branch** [required] - The branch you wish to start the build for
+- **options** [optional] - Additional parameters you can pass in
+
+#### Example Usage with additional parameters
+
+```javascript
+ci.startBuild({
+  username: "jpstevens",
+  project: "circleci",
+  branch: "master",
+  body:
+    parallel: null
+    revision: null
+    build_parameters:
+      NODE_ENV: "production"
+      FOO: "bar"
+}).then(function(build){
+  console.log(build);
+});
+```  
 
 ### cancelBuild
 


### PR DESCRIPTION
- [x] Removes statement regarding lack of support of build_params 

- [x] Adds new documentation for `options`

See #12 