### PR TITLE
Adding support for self hosted instances

### DIFF
--- a/src/circleci-request.coffee
+++ b/src/circleci-request.coffee
@@ -6,7 +6,7 @@ CircleCIResponse = require "./circleci-response"
 class CircleCIRequest
 
   constructor: (config = {}) ->
-    @url = "https://circleci.com/api/v1/"
+    @url = config.url || "https://circleci.com/api/v1/"
     @auth = config.auth
     @request = require "request"
 


### PR DESCRIPTION
Right now is impossible to use the client with self hosted versions of circle.
Exposing this configuration property would enable it